### PR TITLE
Default props example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ const Button = styled.button`
   color: ${styledProps(color, 'color')}
 `;
 Button.defaultProps = {
-  color: 'white',
+  color: 'primary',
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ const Button = styled.button`
   color: ${styledProps(color, 'color')}
 `;
 Button.defaultProps = {
-  color: 'primary',
+  color: 'default',
 };
 ```
 


### PR DESCRIPTION
In the demo https://webpackbin.herokuapp.com/NkSd_zRBM
the example for default props it's
```js
Button.defaultProps = {
  size: 'medium',
  background: 'primary',
  color: 'primary',
  borderRadius: 'default'
};
```
but in the readme it's
```js
const Button = styled.button`
  color: ${styledProps(color, 'color')}
`;
Button.defaultProps = {
  color: 'white',
};
```
export default Button;

The example in the readme i'ts confusing because in my case I expeted get a withe color
